### PR TITLE
Feat/keep login

### DIFF
--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -1,16 +1,23 @@
-import React from 'react';
-import {Link} from 'react-router-dom';
-import '../../styles/Header.css';
+import React from "react";
+import { Link } from "react-router-dom";
+import "../../styles/Header.css";
 
 const Header = ({ onLogout }) => (
-    <div className="header">
-        <Link to={"/"}>
-            <div className="logo">LOGO</div>
-        </Link>
-        {/*<div className="logout">*/}
-        {/*    logout..?*/}
-        {/*</div>*/}
-    </div>
+	<div className="header">
+		<Link to={"/"}>
+			<div className="logo">LOGO</div>
+		</Link>
+		<Link to={"/"}>
+			<button className="logoutBtn" onClick={handleLogout}>
+				logout
+			</button>
+		</Link>
+	</div>
 );
+
+const handleLogout = () => {
+	localStorage.clear();
+	alert("Logout 되었습니다");
+};
 
 export default Header;

--- a/src/components/login/LoginStatus.js
+++ b/src/components/login/LoginStatus.js
@@ -1,0 +1,14 @@
+import React, { useEffect, useState } from "react";
+
+export default function LoginStatus() {
+	const [user, setUser] = useState();
+	useEffect(() => {
+		const loggedInUser = localStorage.getItem("user");
+		if (loggedInUser) {
+			const foundUser = JSON.parse(loggedInUser);
+			setUser(foundUser);
+			console.log("get from local storage: ", user);
+		}
+	}, []);
+}
+//당장 필요한 코드는 아니나 추후에 로그인 상태 확인 위해 필요!!

--- a/src/components/waitingRoom/MkRoom.js
+++ b/src/components/waitingRoom/MkRoom.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function MkRoom() {
+	return <div></div>;
+}

--- a/src/components/waitingRoom/ResetList.js
+++ b/src/components/waitingRoom/ResetList.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ResetList({ resetContainer }) {
+	return <button onClick={resetContainer}>초기화</button>;
+}

--- a/src/components/waitingRoom/RoomContainer.css
+++ b/src/components/waitingRoom/RoomContainer.css
@@ -1,0 +1,21 @@
+li {
+	display: inline-block;
+	width: 300px;
+	list-style: none;
+
+	padding: 3px;
+	margin: 10px;
+}
+.basicImg {
+	height: auto;
+	width: 300px;
+	margin: 0%;
+	padding: 10px;
+}
+.roomTitle {
+	width: 300px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	padding-left: 10px;
+}

--- a/src/components/waitingRoom/RoomContainer.js
+++ b/src/components/waitingRoom/RoomContainer.js
@@ -1,0 +1,16 @@
+import React from "react";
+import basicImg from "../../images/study_with_me.jpg";
+
+import "./RoomContainer.css";
+export default function RoomContainer({ renderList }) {
+	return (
+		<ul>
+			{renderList.map((room, idx) => (
+				<li key={idx}>
+					<img className="basicImg" src={basicImg} alt="no image" />
+					<div className="roomTitle">{room.title}</div>
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/src/components/waitingRoom/RoomSearchBox.js
+++ b/src/components/waitingRoom/RoomSearchBox.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+
+export default function RoomSearchBox({
+	roomList,
+	manageRoomContainer,
+	resetContainer,
+}) {
+	const [searchTitle, setSearchTitle] = useState("");
+	const handleSearch = (e) => {
+		setSearchTitle(e.target.value);
+	};
+	const handleBtn = () => {
+		const result = roomList.filter((data) => data.title === searchTitle);
+		manageRoomContainer(result); //필터링 된 결과값이 null이면 전체리스트, 있으면 해당 결과를 랜더링..
+	};
+	return (
+		<div>
+			<input
+				style={{ padding: "10px" }}
+				type="text"
+				placeholder="방 제목 검색"
+				onChange={handleSearch}
+				name="title"
+				value={searchTitle}
+			/>
+			&nbsp;
+			<button style={{ padding: "8px" }} onClick={handleBtn}>
+				검색
+			</button>
+			&nbsp;
+			<button style={{ padding: "8px" }} onClick={resetContainer}>
+				초기화
+			</button>
+		</div>
+	);
+}

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -2,20 +2,21 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Header from "../components/layout/Header";
 import LoginForm from "../components/login/LoginForm";
+import LoginStatus from "../components/login/LoginStatus";
 import axios from "axios";
 function Login(props) {
 	const [inputs, setInputs] = useState({
 		userId: "",
 		userPw: "",
 	});
-
 	const { userId, userPw } = inputs;
+	const { loginStatus, setLoginStatus } = useState();
 	const onChange = (e) => {
 		const { name, value } = e.target;
 		setInputs({ ...inputs, [name]: value });
 	};
 
-	const handleSubmit = (e) => {
+	const handleSubmit = async (e) => {
 		const test = {
 			userId: userId,
 			title: userPw,
@@ -31,14 +32,21 @@ function Login(props) {
 
 		e.preventDefault();
 		console.log(test); //넘어가는값 확인용. 추후 삭제
-		axios
+		await axios
 			.post(url, test)
 			.then((response) => {
-				console.log(response);
+				console.log("response: ", response);
+				if (response.status === 201) {
+					localStorage.setItem("user", JSON.stringify(response.data));
+					console.log("response.data: ", response.data);
+				}
 			})
 			.catch((error) => {
 				console.log("registration error", error);
 			});
+		//local storage확인용 ..추후 삭제
+		const myName = localStorage.getItem("user");
+		console.log("myname: ", JSON.parse(myName));
 	};
 	return (
 		<div>
@@ -49,6 +57,7 @@ function Login(props) {
 				<button type="submit">Login</button>
 			</form>
 			<br />
+			{/* {() => loginStatus()} */}
 			<Link to="/rooms">link to room</Link>
 		</div>
 	);

--- a/src/pages/Rooms.js
+++ b/src/pages/Rooms.js
@@ -1,18 +1,66 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Header from "../components/layout/Header";
-import {Link} from "react-router-dom";
-const Rooms = ({ match }) => {
-    // App.js /:kind로 설정해둔 값입니다.
-    const { roomId } = match.params;
-    return (
-        <div>
-            <Header/>
-            <div>this is waiting room</div>
-            <Link to="./rooms/1"><button>방입장</button></Link>
-        {/*    대기방->방 으로 이동하는거 확인용 버튼..의미 없음*/}
-        </div>
-    //대기방
-    );
-};
+import { Link } from "react-router-dom";
+import axios from "axios";
+import RoomSearchBox from "../components/waitingRoom/RoomSearchBox";
+import MkRoom from "../components/waitingRoom/MkRoom";
+import RoomContainer from "../components/waitingRoom/RoomContainer";
+
+function Rooms() {
+	const [roomList, setRoomList] = useState([]); //서버에서 가져온 값 저장.
+	const [renderList, setRenderList] = useState([]); //실제 렌더링 될 객체를 저장하고 있다.
+
+	useEffect(() => {
+		axios
+			.get(`https://jsonplaceholder.typicode.com/posts`)
+			.then((res) => {
+				if (res.status === 200) {
+					console.log(res);
+					setRoomList(res.data);
+					setRenderList(res.data);
+				} else {
+					console.log("wrong status");
+				}
+			})
+			.catch((err) => {
+				console.log(err);
+			});
+	}, []);
+
+	const manageRoomContainer = (result) => {
+		if (result.length === 0) {
+			setRenderList(roomList);
+			//no result
+		} else {
+			setRenderList(result);
+			//have result
+		}
+	};
+	const resetContainer = () => {
+		setRenderList(roomList);
+	};
+
+	return (
+		<div>
+			<Header />
+
+			<RoomSearchBox
+				roomList={roomList}
+				manageRoomContainer={manageRoomContainer}
+				resetContainer={resetContainer}
+			/>
+
+			<MkRoom />
+
+			{/* renderlist로 관리하려 헀으나 초기화가 확실히 안되서 일단은 roomList를 인자로 넣었음.. css처리해주고 경우의 수에 맞는 랜더링 할수 있게 고민.. */}
+			<RoomContainer renderList={renderList} />
+		</div>
+	);
+}
 
 export default Rooms;
+
+{
+	/* <Link to="./rooms/1"><button>방입장</button></Link>
+           대기방->방 으로 이동하는거 확인용 버튼..의미 없음 */
+}

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -1,29 +1,34 @@
-.header{
-    background: #333;
-    height: 3rem;
+.header {
+	background: #333;
+	height: 3rem;
 
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 }
-.logout {
-    margin-left: auto;
-    margin-right: 1.5rem;
-    color: white;
 
-    font-weight: bold;
-    font-size: 2rem;
-
-    cursor: pointer;
-}
 .logo {
-    color: white;
+	color: white;
 
-    font-weight: 800;
-    font-size: 1.5rem;
+	font-weight: 800;
+	font-size: 1.5rem;
 
-    cursor: pointer;
+	cursor: pointer;
 
-    margin-left: 1rem;
+	margin-left: 1rem;
 
-    user-select: none;
+	user-select: none;
+}
+.logoutBtn {
+	position: absolute;
+	right: 10px;
+	top: 5px;
+	padding-bottom: 0.5rem;
+	padding-top: 0.5rem;
+	color: white;
+	background: teal;
+	border: 1px solid teal;
+	border-radius: 0.25rem;
+}
+.logoutBtn:hover {
+	background-color: #26a69a;
 }


### PR DESCRIPTION
login: localStorage에 로그인 정보 저장해서 로그인 상태 유지 가능하도록 처리
header: 로그아웃 버튼 추가. 클릭시 알림창 뜨고 local storage에서 로그인 정보 지워버리고, home으로 이동하도록 처리
대기방:
 jsonholder에서 타이틀만 받아오고, 이미지는 기본 이미지로 채움. 추후 api 받으면 거기서 title이랑 이미지 뽑아서 처리하면 될거 같음
검색 기능 추가. 이름 넣고 검색하면 해당 이미지만 나오고, 초기화 누르면 전체 리스트 있는거 다시 가져옴.
->추후 일정:
1. 이미지 누르면 해당 방으로 이동하도록 처리
2. 검색란 중앙으로 이동
3. 로고명 변경
